### PR TITLE
fix(logging): remove public access from log functions to prevent global pollution

### DIFF
--- a/SelectedTextKitExample/ContentView.swift
+++ b/SelectedTextKitExample/ContentView.swift
@@ -142,7 +142,7 @@ struct ContentView: View {
             isLoading = false
             
             if let selectedTextFrame = try? AXManager.shared.getSelectedTextFrame() {
-                logInfo("Selected text frame: \(selectedTextFrame.rectValue)" )
+                print("Selected text frame: \(selectedTextFrame.rectValue)" )
             }
         }
     }

--- a/Sources/SelectedTextKit/Utilities/Logging.swift
+++ b/Sources/SelectedTextKit/Utilities/Logging.swift
@@ -27,11 +27,11 @@ public var logTimestamp: String {
 }
 
 /// Log info message with timestamp
-public func logInfo(_ message: String) {
+func logInfo(_ message: String) {
     logger.info("[\(logTimestamp)] \(message)")
 }
 
 /// Log error message with timestamp
-public func logError(_ message: String) {
+func logError(_ message: String) {
     logger.error("[\(logTimestamp)] \(message)")
 }


### PR DESCRIPTION
This commit addresses a potential global namespace pollution issue by removing the `public` access modifier from logging functions in Logging.swift.

The changes:
- Removed `public` keyword from `logInfo()` and `logError()` functions
- Updated ContentView.swift to use `print()` instead of `logInfo()` for the selected text frame output

This ensures the logging functions remain private to the module while preventing unnecessary exposure of internal utilities.