### PR TITLE
Mark pasteboard restore as transient (nspasteboard.com convention)

### DIFF
--- a/Sources/SelectedTextKit/Pasteboard/Extensions/NSPasteboard+Extension.swift
+++ b/Sources/SelectedTextKit/Pasteboard/Extensions/NSPasteboard+Extension.swift
@@ -9,15 +9,36 @@
 import AppKit
 
 extension NSPasteboard {
+    /// Pasteboard type marker used to opt the restored contents OUT of
+    /// clipboard-history recording in well-behaved clipboard managers
+    /// (Maccy, Pastebot, Alfred, LaunchBar, PopClip, …). The convention
+    /// is documented at https://nspasteboard.com/. Setting this on the
+    /// final restore step makes the round-trip invisible to history
+    /// listeners — exactly what callers expect from a "temporary task".
+    public static let transientType = NSPasteboard.PasteboardType(
+        rawValue: "org.nspasteboard.TransientType"
+    )
+
     /// Protect the pasteboard items from being changed by temporary tasks.
     /// This method will backup current pasteboard contents, execute the task, and then restore the original contents.
     ///
+    /// The restore step is marked with `org.nspasteboard.TransientType`
+    /// (https://nspasteboard.com/) so clipboard managers skip it — the
+    /// whole point of `performTemporaryTask` is to leave no user-visible
+    /// trace of the round-trip, and the marker is the standard way to
+    /// communicate "this write is transient" to history consumers.
+    ///
     /// - Parameters:
     ///   - restoreInterval: Delay before restoring contents
+    ///   - markRestoreAsTransient: When `true` (default) the restore
+    ///     declares the nspasteboard transient marker. Set `false` to
+    ///     opt out — useful if a caller explicitly wants the restored
+    ///     state to look like a fresh user copy.
     ///   - task: The async task to execute
     @MainActor
     public func performTemporaryTask(
         restoreInterval: TimeInterval = 0.0,
+        markRestoreAsTransient: Bool = true,
         task: @escaping () async -> Void
     ) async {
         let savedItems = backupItems()
@@ -26,7 +47,7 @@ extension NSPasteboard {
 
         await Task.sleep(seconds: restoreInterval)
 
-        restoreItems(savedItems)
+        restoreItems(savedItems, markAsTransient: markRestoreAsTransient)
     }
 }
 
@@ -68,15 +89,36 @@ extension NSPasteboard {
         return itemsToBackup
     }
 
-    /// Restore pasteboard contents from saved items
-    /// - Parameter pasteboardItems: Array of pasteboard items to restore
-    /// - Returns: True if restoration was successful, false otherwise
+    /// Restore pasteboard contents from saved items.
+    ///
+    /// - Parameters:
+    ///   - pasteboardItems: Array of pasteboard items to restore.
+    ///   - markAsTransient: When `true` (default) the restore declares
+    ///     `org.nspasteboard.TransientType` so well-behaved clipboard
+    ///     managers (Maccy, Pastebot, etc.) skip the entry. The marker
+    ///     is added as an empty-string value on each restored item, so
+    ///     all original data types remain readable.
+    /// - Returns: True if restoration was successful, false otherwise.
     @MainActor
     @discardableResult
-    @objc public func restoreItems(_ pasteboardItems: [NSPasteboardItem]) -> Bool {
+    @objc public func restoreItems(
+        _ pasteboardItems: [NSPasteboardItem],
+        markAsTransient: Bool = true
+    ) -> Bool {
         guard !pasteboardItems.isEmpty else {
             logInfo("No pasteboard items to restore")
             return false
+        }
+
+        if markAsTransient {
+            // Re-add the marker on each restored item. Clipboard managers
+            // check `pasteboard.types` (or per-item `types`) for the
+            // marker before recording, so it must be present at the time
+            // of the write — declaring it later would not retroactively
+            // suppress the change-count tick.
+            for item in pasteboardItems {
+                item.setString("", forType: NSPasteboard.transientType)
+            }
         }
 
         clearContents()


### PR DESCRIPTION
## Summary

`performTemporaryTask` saves the pasteboard, runs a task that overwrites it, and restores the original. The restore step writes the original data back as a fresh pasteboard write — which clipboard managers (Maccy, Pastebot, Alfred, LaunchBar, PopClip, …) record as a real user copy. So every selection capture done via SelectedTextKit's `.menuAction` / `.shortcut` strategies leaves a duplicate entry in users' clipboard history, immediately replaced by the next real copy.

The [nspasteboard.com convention](https://nspasteboard.com/) defines `org.nspasteboard.TransientType` as a marker indicating "this write is transient, please don't record it." Every major clipboard manager honours it. Setting the marker on each restored `NSPasteboardItem` makes the round-trip invisible to history without changing the actual data shape.

## What changes

- `restoreItems(_:markAsTransient:)` — new optional parameter, defaults `true`. Adds `org.nspasteboard.TransientType` as an empty-string value on each restored item before writing.
- `performTemporaryTask(restoreInterval:markRestoreAsTransient:task:)` — new optional parameter, defaults `true`. Threads through to `restoreItems`.
- New `NSPasteboard.transientType` static — convenience constant for the marker type.

Both new params are opt-out, so callers that explicitly want the restore to look like a fresh user copy can pass `false`.

## Test plan

- [ ] Existing `performTemporaryTask` callers compile unchanged (default-true on the new param).
- [ ] Run a `.shortcut` capture in a Maccy-equipped environment; verify no new history entry appears for the restore step.
- [ ] Run with `markRestoreAsTransient: false`; verify history DOES record the restore (regression check that the opt-out path still works).
- [ ] Confirm `restoreItems` still reports `false` on empty arrays + the success of `writeObjects` is unchanged.

## Why this default

For `performTemporaryTask`'s callers (selection capture, paste-with-restore), the restore step is *definitionally* not a user-initiated copy — it's the library returning the pasteboard to the state it found it in. Recording it would be a bug from the user's perspective. Defaulting the marker on aligns with what every clipboard tool that uses save-and-restore (PopClip, Raycast, Alfred's text actions) already does.